### PR TITLE
Use saved photos instead of redownloading. Fix Explorer scroll

### DIFF
--- a/SnapCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SnapCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "db40f1076af73855a94230f921b4447982958943",
-          "version": null
+          "revision": "49e808315df3add5f77f2c786724e77ba3129dbe",
+          "version": "1.9.1"
         }
       }
     ]

--- a/SnapCat/Constants.swift
+++ b/SnapCat/Constants.swift
@@ -12,6 +12,7 @@ enum Constants {
     static let firstRun                         = "FirstRun"
     static let lastProfilePicURL                = "lastProfilePicURL"
     static let numberOfImagesToDownload         = 50
+    static let fileDownloadsDirectory           = "Downloads"
 }
 
 // MARK: - Standard Parse Class Keys

--- a/SnapCat/Explore/ExploreView.swift
+++ b/SnapCat/Explore/ExploreView.swift
@@ -17,7 +17,7 @@ struct ExploreView: View {
     var body: some View {
         if !viewModel.users.isEmpty {
             NavigationView {
-                VStack {
+                ScrollView {
                     SearchBarView(searchText: $searchText)
                     ForEach(viewModel
                                 .users


### PR DESCRIPTION
- [x] Reuse saved pictures instead of downloading again
- [x] Fix explorer view to use scroll
- [x] Update ParseSwift to 1.9.1