### PR TITLE
Update to ParseSwift 2.2.6

### DIFF
--- a/SnapCat.xcodeproj/project.pbxproj
+++ b/SnapCat.xcodeproj/project.pbxproj
@@ -902,7 +902,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.4;
+				minimumVersion = 2.2.6;
 			};
 		};
 		916E09752691D61100356C08 /* XCRemoteSwiftPackageReference "DZNEmptyDataSet" */ = {

--- a/SnapCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SnapCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "7c6c3050d03657682e6811b02d9b0d6726e29e43",
-          "version": "2.2.3"
+          "revision": "b4bdfb12ee980add480fcf30ddcead5a49509a72",
+          "version": "2.2.6"
         }
       }
     ]

--- a/SnapCat/Models/Activity.swift
+++ b/SnapCat/Models/Activity.swift
@@ -62,6 +62,5 @@ extension Activity {
         self.type = type
         self.fromUser = fromUser
         self.toUser = toUser
-        ACL = try? ParseACL.defaultACL()
     }
 }

--- a/SnapCat/Models/Post.swift
+++ b/SnapCat/Models/Post.swift
@@ -28,6 +28,5 @@ extension Post {
     init(image: ParseFile? = nil) {
         user = User.current
         self.image = image
-        ACL = try? ParseACL.defaultACL()
     }
 }


### PR DESCRIPTION
Allow SDK to set default ACL's to objects